### PR TITLE
feat(schema) Support external JSON schemas

### DIFF
--- a/.atoum.php
+++ b/.atoum.php
@@ -3,5 +3,7 @@
 $extension = new atoum\apiblueprint\extension($script);
 $extension->addToRunner($runner);
 
-$extension->getAPIBFinder()->append(new FilesystemIterator(__DIR__ . '/test/system'));
+$extension->getConfiguration()->mountJsonSchemaDirectory('test', __DIR__ . '/test/system/schemas/');
+$extension->getAPIBFinder()->append(new FilesystemIterator(__DIR__ . '/test/system/'));
+
 $extension->compileAndEnqueue();

--- a/README.md
+++ b/README.md
@@ -36,6 +36,32 @@ $extension->getAPIBFinder()->append(new FilesystemIterator('./apiblueprints'));
 $extension->compileAndEnqueue();
 ```
 
+### JSON schemas defined outside `.apib` files
+
+It is possible to define JSON schemas outside the `.apib` files. To do
+so, you must go through these 2 steps:
+
+  1. Mount a JSON schema directory on the extension's configuration,
+  2. Use `{"$ref": "json-schema://<mount>/schema.json"}` in the Schema
+     section of the API Blueprint documentation.
+     
+Example:
+
+  1. ```php
+     // .atoum.php
+     $extension->getConfiguration()->mountJsonSchemaDirectory('test', '/path/to/schemas/');
+     ```
+  2. ```apib
+     // my-spec.apib
+     + Response 200
+
+       + Schema
+
+         {"$ref": "json-schema://test/my-schema.json"}
+     ```
+     where `test` is the “mount name”, and `my-schema.json` is a valid
+     JSON schema in `/path/to/schemas/my-schema.json`.
+
 ## Testing
 
 Before running the test suites, the development dependencies must be installed:

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace atoum\apiblueprint;
+
+use mageekguy\atoum;
+use RuntimeException;
+
+class Configuration implements atoum\extension\configuration
+{
+    protected $_jsonSchemaMountPoints = [];
+
+    public function mountJsonSchemaDirectory(string $rootName, string $directory)
+    {
+        $_directory = realpath($directory);
+
+        if (false === $_directory || false === is_dir($_directory)) {
+            throw new RuntimeException(
+                'Try to mount the `' . $directory . '` directory ' .
+                'as `' . $rootName . '`, but it does not exist.'
+            );
+        }
+
+        $this->_jsonSchemaMountPoints[$rootName] = $_directory;
+    }
+
+    public function unmountJsonSchemaDirectory(string $rootName)
+    {
+        unset($this->_router[$rootName]);
+    }
+
+    public function getJsonSchemaMountPoints(): array
+    {
+        return $this->_jsonSchemaMountPoints;
+    }
+
+    public function serialize()
+    {
+        return [
+            'jsonSchemaMountPoints' => $this->getJsonSchemaMountPoints()
+        ];
+    }
+
+    public static function unserialize(array $configuration)
+    {
+        $self = new static();
+
+        if (isset($configuration['jsonSchemaMountPoints'])) {
+            $self->_jsonSchemaMountPoints = $configuration['jsonSchemaMountPoints'];
+        }
+
+        return $self;
+    }
+}

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -11,6 +11,15 @@ class Configuration implements atoum\extension\configuration
 {
     protected $_jsonSchemaMountPoints = [];
 
+    /**
+     * JSON schemas can be declared outside to the `.apib` files. To access
+     * them, the user must use the `json-schema://host/path` URL
+     * (e.g. `{"$ref": "json-schema://…"}`), where:
+     *
+     *   * `host` is the `$rootName`, and
+     *   * The concatenation of `$directory` and `path` produces a valid path to a
+     *     JSON schema file.
+     */
     public function mountJsonSchemaDirectory(string $rootName, string $directory)
     {
         $_directory = realpath($directory);
@@ -25,16 +34,25 @@ class Configuration implements atoum\extension\configuration
         $this->_jsonSchemaMountPoints[$rootName] = $_directory;
     }
 
+    /**
+     * Remove a JSON schema directory that might have been mounted.
+     */
     public function unmountJsonSchemaDirectory(string $rootName)
     {
         unset($this->_router[$rootName]);
     }
 
+    /**
+     * Returns all the JSON schema mount points.
+     */
     public function getJsonSchemaMountPoints(): array
     {
         return $this->_jsonSchemaMountPoints;
     }
 
+    /**
+     * “Serialize” the configuration as an array.
+     */
     public function serialize()
     {
         return [
@@ -42,6 +60,9 @@ class Configuration implements atoum\extension\configuration
         ];
     }
 
+    /**
+     * Allocate a `Configuration` object based on an array of data.
+     */
     public static function unserialize(array $configuration)
     {
         $self = new static();

--- a/src/JsonSchema/UriRetriever.php
+++ b/src/JsonSchema/UriRetriever.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace atoum\apiblueprint\JsonSchema;
+
+use JsonSchema\Uri\Retrievers\FileGetContents;
+
+class UriRetriever extends FileGetContents
+{
+    protected $_router = [];
+
+    public function retrieve($uri)
+    {
+        $parsed = parse_url($uri);
+        $scheme = $parsed['scheme'] ?? '';
+        $root   = $parsed['host'] ?? '';
+        $path   = $parsed['path'] ?? '';
+
+        if ('json-schema' === $scheme &&
+            !empty($root) &&
+            !empty($path) &&
+            isset($this->_router[$root]) &&
+            true === file_exists($this->_router[$root] . $path)) {
+            return parent::retrieve($this->_router[$root] . $path);
+        }
+
+        return parent::retrieve($uri);
+    }
+
+    public function mount(string $rootName, string $rootPath)
+    {
+        $this->_router[$rootName] = $rootPath . DIRECTORY_SEPARATOR;
+    }
+
+    public function unmount(string $rootName)
+    {
+        unset($this->_router[$rootName]);
+    }
+
+    public function get()
+    {
+        return $this->_router;
+    }
+}

--- a/src/JsonSchema/UriRetriever.php
+++ b/src/JsonSchema/UriRetriever.php
@@ -10,6 +10,15 @@ class UriRetriever extends FileGetContents
 {
     protected $_router = [];
 
+    /**
+     * JSON schemas can be declared outside to the `.apib` files. To access
+     * them, the user must use the `json-schema://host/path` URL
+     * (e.g. `{"$ref": "json-schema://…"}`), where:
+     *
+     *   * `host` is a mounted directory,
+     *   * The concatenation of the mounted directory and `path` produces a
+     *     valid path to a JSON schema file.
+     */
     public function retrieve($uri)
     {
         $parsed = parse_url($uri);
@@ -28,6 +37,9 @@ class UriRetriever extends FileGetContents
         return parent::retrieve($uri);
     }
 
+    /**
+     * Mount a directory.
+     */
     public function mount(string $rootName, string $rootPath)
     {
         $this->_router[$rootName] = $rootPath . DIRECTORY_SEPARATOR;
@@ -36,10 +48,5 @@ class UriRetriever extends FileGetContents
     public function unmount(string $rootName)
     {
         unset($this->_router[$rootName]);
-    }
-
-    public function get()
-    {
-        return $this->_router;
     }
 }

--- a/src/test.php
+++ b/src/test.php
@@ -18,6 +18,9 @@ class test extends atoum\test
         return '\\';
     }
 
+    /**
+     * Configure the `$this->json(…)` asserter.
+     */
     public function setJsonHandler(Configuration $configuration)
     {
         $jsonSchemaUriRetriever = new JsonSchema\UriRetriever();
@@ -46,6 +49,10 @@ class test extends atoum\test
             );
     }
 
+    /**
+     * The `responsesMatch` asserter checks that a collection of responses are
+     * valid regarding a collection of expected responses.
+     */
     public function responsesMatch(\Generator $responses, array $expectedResponses): self
     {
         foreach ($responses as $i => $response) {

--- a/src/test.php
+++ b/src/test.php
@@ -18,6 +18,34 @@ class test extends atoum\test
         return '\\';
     }
 
+    public function setJsonHandler(Configuration $configuration)
+    {
+        $jsonSchemaUriRetriever = new JsonSchema\UriRetriever();
+
+        foreach ($configuration->getJsonSchemaMountPoints() as $mountName => $mountValue) {
+            $jsonSchemaUriRetriever->mount($mountName, $mountValue);
+        }
+
+        $self         = $this;
+        $jsonAsserter = null;
+
+        $this
+            ->getAssertionManager()
+            ->setHandler(
+                'json',
+                function ($json) use ($self, &$jsonAsserter, $jsonSchemaUriRetriever) {
+                    if (null === $jsonAsserter) {
+                        $jsonAsserter = new Asserter\Json($self->getAsserterGenerator());
+                        $jsonAsserter->setJsonSchemaUriRetriever($jsonSchemaUriRetriever);
+                    }
+
+                    $jsonAsserter->setWithTest($self);
+
+                    return $jsonAsserter->setWith($json, null, null);
+                }
+            );
+    }
+
     public function responsesMatch(\Generator $responses, array $expectedResponses): self
     {
         foreach ($responses as $i => $response) {

--- a/test/integration/ApibToTestSuites/SchemaExternal.test
+++ b/test/integration/ApibToTestSuites/SchemaExternal.test
@@ -1,0 +1,55 @@
+FORMAT: 1A
+HOST: https://example.org/
+
+# API Name
+
+# R 1 [/group/a/resource/1]
+
+## Foo Bar [GET /group/a/resource/1/action/foo-bar]
+
++ Response 200 (media/type2)
+
+  + Schema
+
+    {
+        "$ref": "foobar.json"
+    }
+
+---[to]---
+
+namespace atoum\apiblueprint\generated;
+
+class API Name extends \atoum\apiblueprint\test
+{
+    protected $_host = null;
+
+    public function beforeTestMethod($testMethod)
+    {
+        $this->_host = 'https://example.org/';
+    }
+
+    public function test resource r 1 action foo bar transaction 0()
+    {
+        $requester = new \atoum\apiblueprint\Http\Requester();
+        $expectedResponses = [];
+
+        $requester->addRequest(
+            'GET',
+            $this->_host . '/group/a/resource/1/action/foo-bar',
+            [
+            ]
+        );
+        $expectedResponses[] = [
+            'statusCode' => 200,
+            'mediaType'  => 'media/type2',
+            'headers'    => [
+            ],
+            'body'       => '',
+            'schema'     => '{
+"$ref": "foobar.json"
+}',
+        ];
+
+        $this->responsesMatch($requester->send(), $expectedResponses);
+    }
+}

--- a/test/system/schemaExternal.apib
+++ b/test/system/schemaExternal.apib
@@ -1,0 +1,16 @@
+FORMAT: 1A
+HOST: http://127.0.0.1:8888/
+
+# External Schema
+
+# R 1 [/schema]
+
+## Foo Bar [GET]
+
++ Response 200 (application/json)
+
+  + Schema
+
+    {
+        "$ref": "json-schema://test/schema1.json"
+    }

--- a/test/system/schemas/schema1.json
+++ b/test/system/schemas/schema1.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "message": {
+            "type": "string"
+        }
+    }
+}


### PR DESCRIPTION
To define an external JSON schema, one might go through the following
steps:

  1. Mount a JSON schema directory on the extension's configuration,
  2. Use `{"$ref": "json-schema://<mount>/schema.json"}` in the Schema
     section of the API Blueprint documentation.

Example. In `.atoum.php`:

```php
$extension->getConfiguration()->mountJsonSchemaDirectory('test', '/path/to/schemas/');
```

`file.apib`:
```apib
  + Schema

    {"$ref": "json-schema://test/my-schema.json"}
```